### PR TITLE
Make `StackBox` `Send`/`Sync` (when `T` is) when alloc feature is not enabled

### DIFF
--- a/src/ptr.rs
+++ b/src/ptr.rs
@@ -13,138 +13,91 @@
 //! to stable Rust… 😩
 
 #[allow(unused_imports)]
-pub(in crate)
-use ::core::ptr::*;
+pub(crate) use ::core::ptr::*;
 
-pub(in crate)
-use __::Unique;
+pub(crate) use __::Unique;
 
 #[cfg(feature = "alloc")]
-pub(in crate)
-mod __ {
+pub(crate) mod __ {
     use ::alloc::boxed::Box;
-    use ::core::{
-        mem::ManuallyDrop as MD,
-        ptr,
-    };
+    use ::core::{mem::ManuallyDrop as MD, ptr};
 
     #[repr(transparent)]
-    pub(in crate)
-    struct Unique<T : ?Sized> /* = */ (
-        MD<Box<T>>,
-    );
+    pub(crate) struct Unique<T: ?Sized>(MD<Box<T>>);
 
-    impl<T : ?Sized> Unique<T> {
+    impl<T: ?Sized> Unique<T> {
         #[inline]
-        pub(in crate)
-        unsafe
-        fn from_raw (ptr: *mut T)
-          -> Unique<T>
-        {
+        pub(crate) unsafe fn from_raw(ptr: *mut T) -> Unique<T> {
             Self(MD::new(Box::from_raw(ptr)))
         }
 
         #[inline]
-        pub(in crate)
-        fn into_raw_nonnull (self: Unique<T>)
-          -> ptr::NonNull<T>
-        {
-            Box::leak(MD::into_inner(self.0))
-                .into()
+        pub(crate) fn into_raw_nonnull(self: Unique<T>) -> ptr::NonNull<T> {
+            Box::leak(MD::into_inner(self.0)).into()
         }
 
         #[inline]
-        pub(in crate)
-        unsafe
-        fn drop_in_place (this: &'_ mut Unique<T>)
-        {
+        pub(crate) unsafe fn drop_in_place(this: &'_ mut Unique<T>) {
             ptr::drop_in_place::<T>(&mut **this)
         }
     }
 
-    impl<T : ?Sized> ::core::ops::Deref
-        for Unique<T>
-    {
+    impl<T: ?Sized> ::core::ops::Deref for Unique<T> {
         type Target = T;
 
         #[inline]
-        fn deref (self: &'_ Unique<T>)
-          -> &'_ T
-        {
+        fn deref(self: &'_ Unique<T>) -> &'_ T {
             &**self.0
         }
     }
 
-    impl<T : ?Sized> ::core::ops::DerefMut
-        for Unique<T>
-    {
+    impl<T: ?Sized> ::core::ops::DerefMut for Unique<T> {
         #[inline]
-        fn deref_mut (self: &'_ mut Unique<T>)
-          -> &'_ mut T
-        {
+        fn deref_mut(self: &'_ mut Unique<T>) -> &'_ mut T {
             &mut **self.0
         }
     }
 }
 
 #[cfg(not(feature = "alloc"))]
-pub(in crate)
-mod __ {
+pub(crate) mod __ {
     use ::core::ptr;
 
     #[repr(transparent)]
-    pub(in crate)
-    struct Unique<T : ?Sized> /* = */ (
-        ptr::NonNull<T>,
-    );
+    pub(crate) struct Unique<T: ?Sized>(ptr::NonNull<T>);
 
-    impl<T : ?Sized> Unique<T> {
+    unsafe impl<T: Send + ?Sized> Send for Unique<T> {}
+    unsafe impl<T: Sync + ?Sized> Sync for Unique<T> {}
+
+    impl<T: ?Sized> Unique<T> {
         #[inline]
-        pub(in crate)
-        unsafe
-        fn from_raw (ptr: *mut T)
-          -> Unique<T>
-        {
+        pub(crate) unsafe fn from_raw(ptr: *mut T) -> Unique<T> {
             Self(ptr::NonNull::new_unchecked(ptr))
         }
 
         #[inline]
-        pub(in crate)
-        fn into_raw_nonnull (self: Unique<T>)
-          -> ptr::NonNull<T>
-        {
+        pub(crate) fn into_raw_nonnull(self: Unique<T>) -> ptr::NonNull<T> {
             self.0
         }
 
         #[inline]
-        pub(in crate)
-        unsafe
-        fn drop_in_place (this: &'_ mut Unique<T>)
-        {
+        pub(crate) unsafe fn drop_in_place(this: &'_ mut Unique<T>) {
             ptr::drop_in_place(this.0.as_ptr())
         }
     }
 
-    impl<T : ?Sized> ::core::ops::Deref
-        for Unique<T>
-    {
+    impl<T: ?Sized> ::core::ops::Deref for Unique<T> {
         type Target = T;
 
         #[inline]
-        fn deref (self: &'_ Unique<T>)
-          -> &'_ T
-        {
+        fn deref(self: &'_ Unique<T>) -> &'_ T {
             unsafe { self.0.as_ref() }
         }
     }
 
-    impl<T : ?Sized> ::core::ops::DerefMut
-        for Unique<T>
-    {
+    impl<T: ?Sized> ::core::ops::DerefMut for Unique<T> {
         #[inline]
-        fn deref_mut (self: &'_ mut Unique<T>)
-          -> &'_ mut T
-        {
+        fn deref_mut(self: &'_ mut Unique<T>) -> &'_ mut T {
             unsafe { self.0.as_mut() }
         }
     }


### PR DESCRIPTION
When the `"alloc"` feature isn't enabled `Unique<T>` is implement as `NotNull<T>` so it isn't `Send` or `Sync` by default. Since `StackBox` uses `Unique<T>` this causes it to not be `Send` or `Sync` as well.