### PR TITLE
Slice improvements

### DIFF
--- a/src/dyn_traits/any.rs
+++ b/src/dyn_traits/any.rs
@@ -28,12 +28,7 @@ mod private {
     ///  - `dyn Any + Sync` → `StackBoxDynAny<dyn Sync>`;
     ///
     ///  - `dyn Any + Send + Sync` → `StackBoxDynAny<dyn Send + Sync>`;
-    pub
-    struct StackBoxDynAny<
-            'frame,
-            AutoTraits : ?Sized + T::Sendness + T::Syncness = NoAutoTraits,
-        >
-    {
+    pub struct StackBoxDynAny<'frame, AutoTraits: ?Sized + T::Sendness + T::Syncness = NoAutoTraits> {
         ptr: ptr::NonNull<ty::Erased>,
         vtable: &'frame VTable,
         _auto_traits: ::core::marker::PhantomData<AutoTraits>,
@@ -43,35 +38,26 @@ mod private {
         drop_in_place: unsafe fn(ptr: ptr::NonNull<ty::Erased>),
         /// could be a `const` if that constructor was made `const`
         type_id: fn() -> TypeId,
-        as_Any:
-            unsafe
-            fn(ptr: ptr::NonNull<ty::Erased>) -> ptr::NonNull<dyn Any + 'static>
-        ,
+        as_Any: unsafe fn(ptr: ptr::NonNull<ty::Erased>) -> ptr::NonNull<dyn Any + 'static>,
     }
 
-    impl<T> HasVTable for T
-    where
-        Self : Sized + Any,
-    {}
+    impl<T> HasVTable for T where Self: Sized + Any {}
     trait HasVTable
     where
-        Self : Sized + Any,
+        Self: Sized + Any,
     {
         const VTABLE: VTable = VTable {
             drop_in_place: {
-                unsafe
-                fn drop_in_place<Self_> (ptr: ptr::NonNull<ty::Erased>)
-                {
+                unsafe fn drop_in_place<Self_>(ptr: ptr::NonNull<ty::Erased>) {
                     ptr::drop_in_place(ptr.cast::<Self_>().as_ptr())
                 }
                 drop_in_place::<Self>
             },
             type_id: || TypeId::of::<Self>(),
             as_Any: {
-                unsafe
-                fn it<Self_ : Any + 'static> (ptr: ptr::NonNull<ty::Erased>)
-                  -> ptr::NonNull<dyn Any + 'static>
-                {
+                unsafe fn it<Self_: Any + 'static>(
+                    ptr: ptr::NonNull<ty::Erased>,
+                ) -> ptr::NonNull<dyn Any + 'static> {
                     let ptr: ptr::NonNull<Self_> = ptr.cast();
                     ptr as ptr::NonNull<dyn Any + 'static>
                 }
@@ -85,7 +71,8 @@ mod private {
         [Sync] => dyn Sync,
         [Send, Sync] => dyn Send + Sync,
         [] => NoAutoTraits,
-    } macro_rules! define_coercions {(
+    }
+    macro_rules! define_coercions {(
         $(
             [$($AutoTrait:ident),* $(,)?] => $Marker:ty
         ),* $(,)?
@@ -121,63 +108,40 @@ mod private {
                     {}
             )*
         )*
-    )} use define_coercions;
+    )}
+    use define_coercions;
 
-    impl<'frame, AutoTraits : ?Sized + T::Sendness + T::Syncness>
-        StackBoxDynAny<'frame, AutoTraits>
-    {
+    impl<'frame, AutoTraits: ?Sized + T::Sendness + T::Syncness> StackBoxDynAny<'frame, AutoTraits> {
         #[inline]
-        pub
-        fn type_id (self: &'_ Self)
-          -> TypeId
-        {
+        pub fn type_id(self: &'_ Self) -> TypeId {
             (self.vtable.type_id)()
         }
 
         #[inline]
-        pub
-        fn is<U : Any> (self: &'_ Self)
-          -> bool
-        {
+        pub fn is<U: Any>(self: &'_ Self) -> bool {
             self.type_id() == TypeId::of::<U>()
         }
 
         #[inline]
-        pub
-        fn downcast_ref<U : Any> (self: &'_ Self)
-          -> Option<&'_ U>
-        {
+        pub fn downcast_ref<U: Any>(self: &'_ Self) -> Option<&'_ U> {
             if self.is::<U>() {
-                unsafe {
-                    Some(::core::mem::transmute(self.ptr))
-                }
+                unsafe { Some(::core::mem::transmute(self.ptr)) }
             } else {
                 None
             }
         }
 
         #[inline]
-        pub
-        fn downcast_mut<U : Any> (self: &'_ mut Self)
-          -> Option<&'_ mut U>
-        {
+        pub fn downcast_mut<U: Any>(self: &'_ mut Self) -> Option<&'_ mut U> {
             if self.is::<U>() {
-                unsafe {
-                    Some(::core::mem::transmute(self.ptr))
-                }
+                unsafe { Some(::core::mem::transmute(self.ptr)) }
             } else {
                 None
             }
         }
 
         #[inline]
-        pub
-        fn downcast<U : Any> (self: Self)
-          -> Result<
-                StackBox<'frame, U>,
-                Self,
-            >
-        {
+        pub fn downcast<U: Any>(self: Self) -> Result<StackBox<'frame, U>, Self> {
             if self.is::<U>() {
                 unsafe {
                     let ptr = ::core::mem::ManuallyDrop::new(self).ptr;
@@ -189,12 +153,11 @@ mod private {
         }
 
         #[inline]
-        pub
-        fn as_Any (self: &'_ Self) -> &'_ (dyn Any + 'static)
-        {
+        pub fn as_Any(self: &'_ Self) -> &'_ (dyn Any + 'static) {
             derive_AsRef_for_auto_trait_combination! {
                 (), (Sync), // (Send), (Send + Sync), /* These should not be required */
-            } macro_rules! derive_AsRef_for_auto_trait_combination {(
+            }
+            macro_rules! derive_AsRef_for_auto_trait_combination {(
                 $(
                     ( $($($auto_traits:tt)+)? )
                 ),* $(,)?
@@ -220,18 +183,18 @@ mod private {
                         }
                     }
                 )*
-            )} use derive_AsRef_for_auto_trait_combination;
+            )}
+            use derive_AsRef_for_auto_trait_combination;
 
             self.as_ref()
         }
 
         #[inline]
-        pub
-        fn as_Any_mut (self: &'_ mut Self) -> &'_ mut (dyn Any + 'static)
-        {
+        pub fn as_Any_mut(self: &'_ mut Self) -> &'_ mut (dyn Any + 'static) {
             derive_AsMut_for_auto_trait_combination! {
                 (), (Send), (Sync), (Send + Sync)
-            } macro_rules! derive_AsMut_for_auto_trait_combination {(
+            }
+            macro_rules! derive_AsMut_for_auto_trait_combination {(
                 $(
                     ( $($($auto_traits:tt)+)? )
                 ),* $(,)?
@@ -257,33 +220,25 @@ mod private {
                         }
                     }
                 )*
-            )} use derive_AsMut_for_auto_trait_combination;
+            )}
+            use derive_AsMut_for_auto_trait_combination;
 
             self.as_mut()
         }
     }
 
-    impl<'frame, AutoTraits : ?Sized + T::Sendness + T::Syncness>
-        Drop
-    for
-        StackBoxDynAny<'frame, AutoTraits>
+    impl<'frame, AutoTraits: ?Sized + T::Sendness + T::Syncness> Drop
+        for StackBoxDynAny<'frame, AutoTraits>
     {
-        fn drop (self: &'_ mut Self)
-        {
-            unsafe {
-                (self.vtable.drop_in_place)(self.ptr)
-            }
+        fn drop(self: &'_ mut Self) {
+            unsafe { (self.vtable.drop_in_place)(self.ptr) }
         }
     }
 
-    impl<'frame, AutoTraits : ?Sized + T::Sendness + T::Syncness>
-        ::core::fmt::Debug
-    for
-        StackBoxDynAny<'frame, AutoTraits>
+    impl<'frame, AutoTraits: ?Sized + T::Sendness + T::Syncness> ::core::fmt::Debug
+        for StackBoxDynAny<'frame, AutoTraits>
     {
-        fn fmt (self: &'_ Self, f: &'_ mut ::core::fmt::Formatter<'_>)
-          -> ::core::fmt::Result
-        {
+        fn fmt(self: &'_ Self, f: &'_ mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
             f.pad("Any")
         }
     }

--- a/src/dyn_traits/fn_once.rs
+++ b/src/dyn_traits/fn_once.rs
@@ -9,9 +9,12 @@
 
 use super::*;
 
-mod T { pub use crate::marker::Sendness::T as Sendness; }
+mod T {
+    pub use crate::marker::Sendness::T as Sendness;
+}
 
-generate!(_9 _8 _7 _6 _5 _4 _3 _2 _1 _0); macro_rules! generate {() => (); (
+generate!(_9 _8 _7 _6 _5 _4 _3 _2 _1 _0);
+macro_rules! generate {() => (); (
     $_N:tt $($_K:tt)*
 ) => (generate! { $($_K)* } ::paste::paste! {
     pub use [<FnOnce$_N>]::[<StackBoxDynFnOnce$_N>];
@@ -161,4 +164,5 @@ generate!(_9 _8 _7 _6 _5 _4 _3 _2 _1 _0); macro_rules! generate {() => (); (
                 [<StackBoxDynFnOnce$_N>]<'frame, $([</*Arg*/$_K>] ,)* Ret, dyn Send>
             {}
     }
-})} use generate;
+})}
+use generate;

--- a/src/dyn_traits/mod.rs
+++ b/src/dyn_traits/mod.rs
@@ -32,13 +32,11 @@
 //!
 //! [`custom_dyn!`]: `crate::custom_dyn`
 
-pub
-mod any;
+pub mod any;
 
 mod custom_dyn;
 
-pub
-mod fn_once;
+pub mod fn_once;
 
 use crate::{
     marker::{NoAutoTraits, Sendness, Syncness},
@@ -46,27 +44,23 @@ use crate::{
 };
 use ::core::ptr;
 
-mod ty { pub struct Erased(()); }
+mod ty {
+    pub struct Erased(());
+}
 
-pub(in crate)
-mod __ {
-    pub
-    trait DynCoerce<StackBoxImplTrait> {
-        fn fatten (it: StackBoxImplTrait)
-          -> Self /* StackBoxDynTrait */
-        ;
+pub(crate) mod __ {
+    pub trait DynCoerce<StackBoxImplTrait> {
+        fn fatten(it: StackBoxImplTrait) -> Self /* StackBoxDynTrait */;
     }
 }
 use __::DynCoerce;
 
-impl<'frame, ImplTrait : 'frame> StackBox<'frame, ImplTrait> {
+impl<'frame, ImplTrait: 'frame> StackBox<'frame, ImplTrait> {
     /// Coerces a `StackBox<impl Trait>` into a `StackBox<dyn Trait>`, provided
     /// the `Trait` is [one of the supported ones][`self`].
-    pub
-    fn into_dyn<StackBoxDynTrait> (self: StackBox<'frame, ImplTrait>)
-      -> StackBoxDynTrait
+    pub fn into_dyn<StackBoxDynTrait>(self: StackBox<'frame, ImplTrait>) -> StackBoxDynTrait
     where
-        StackBoxDynTrait : DynCoerce<StackBox<'frame, ImplTrait>>,
+        StackBoxDynTrait: DynCoerce<StackBox<'frame, ImplTrait>>,
     {
         DynCoerce::fatten(self)
     }
@@ -100,8 +94,7 @@ mod my_test {
     }
 
     #[test]
-    fn fn_once_higher_order_param ()
-    {
+    fn fn_once_higher_order_param() {
         custom_dyn! {
             dyn FnOnceRef<Arg> : FnOnce(&Arg)
             where {
@@ -126,8 +119,7 @@ mod my_test {
     }
 
     #[test]
-    fn manual_any_non_owned_receiver ()
-    {
+    fn manual_any_non_owned_receiver() {
         use ::core::any;
         custom_dyn! {
             dyn Any<'__> : any::Any

--- a/src/dyn_traits/tests.rs
+++ b/src/dyn_traits/tests.rs
@@ -6,21 +6,19 @@ mod any {
     use super::*;
 
     #[test]
-    fn coerce_unsync_unsend_into_any ()
-    {
+    fn coerce_unsync_unsend_into_any() {
         stackbox!(let mut stackbox = ::core::ptr::null::<()>());
         let mut dyn_any: StackBoxDynAny<'_> = stackbox.into_dyn();
         assert!(dyn_any.is::<*const ()>());
         assert!(dyn_any.is::<bool>().not());
         let &(_): &'_ (*const ()) = dyn_any.downcast_ref().unwrap();
-        let &mut(_): &'_ mut (*const ()) = dyn_any.downcast_mut().unwrap();
+        let &mut (_): &'_ mut (*const ()) = dyn_any.downcast_mut().unwrap();
         stackbox = dyn_any.downcast().unwrap();
         drop(stackbox);
     }
 
     #[test]
-    fn coerce_sync_unsend_into_sync_any ()
-    {
+    fn coerce_sync_unsend_into_sync_any() {
         #[derive(Default)]
         struct PhantomUnsend(::core::marker::PhantomData<*mut ()>);
         unsafe impl Sync for PhantomUnsend {}
@@ -30,22 +28,19 @@ mod any {
     }
 
     #[test]
-    fn coerce_send_unsync_into_send_any ()
-    {
+    fn coerce_send_unsync_into_send_any() {
         stackbox!(let stackbox = ::core::cell::Cell::new(0_u8));
         let _: StackBoxDynAny<'_, dyn Send> = stackbox.into_dyn();
     }
 
     #[test]
-    fn coerce_send_sync_into_send_sync_any ()
-    {
+    fn coerce_send_sync_into_send_sync_any() {
         stackbox!(let stackbox = ());
         let _: StackBoxDynAny<'_, dyn Send + Sync> = stackbox.into_dyn();
     }
 
     #[test]
-    fn test_drops ()
-    {
+    fn test_drops() {
         let rc = ::std::rc::Rc::new(());
         let count = || ::std::rc::Rc::strong_count(&rc);
         let rc = || rc.clone();
@@ -112,8 +107,7 @@ mod fn_once {
     use super::*;
 
     #[test]
-    fn move_semantics ()
-    {
+    fn move_semantics() {
         let not_copy: [&'static mut (); 0] = [];
         stackbox!(let stackbox_fn_once = || drop(not_copy));
         let mut dyn_fn_once: StackBoxDynFnOnce_0<'_, ()> = stackbox_fn_once.into_dyn();
@@ -136,11 +130,13 @@ mod fn_once {
     }
 
     #[test]
-    fn test_drops ()
-    {
+    fn test_drops() {
         let rc = ::std::rc::Rc::new(());
         let count = || ::std::rc::Rc::strong_count(&rc);
-        let rc = || { let rc = rc.clone(); move || drop(rc) };
+        let rc = || {
+            let rc = rc.clone();
+            move || drop(rc)
+        };
 
         stackbox!(let stackbox = rc());
         assert_eq!(count(), 2);
@@ -196,12 +192,9 @@ mod custom_dyn {
         }
 
         #[test]
-        fn fn_once_higher_order_param ()
-        {
+        fn fn_once_higher_order_param() {
             stackbox!(let f = |_: &str| ());
-            let f: StackBoxDynFnOnceRef<'_, str, dyn Send + Sync> =
-                f.into_dyn()
-            ;
+            let f: StackBoxDynFnOnceRef<'_, str, dyn Send + Sync> = f.into_dyn();
             let f = |s: &str| f.call(s);
             f("");
         }
@@ -228,11 +221,13 @@ mod custom_dyn {
         }
 
         #[test]
-        fn test_drops ()
-        {
+        fn test_drops() {
             let rc = ::std::rc::Rc::new(());
             let count = || ::std::rc::Rc::strong_count(&rc);
-            let rc = || { let rc = rc.clone(); move |_: &str| drop(rc) };
+            let rc = || {
+                let rc = rc.clone();
+                move |_: &str| drop(rc)
+            };
 
             stackbox!(let stackbox = rc());
             assert_eq!(count(), 2);
@@ -259,7 +254,10 @@ mod custom_dyn {
             assert_eq!(count(), 2);
 
             // The following would fail should the lifetime param not be higher-order
-            if false { f(&String::new()); loop {} }
+            if false {
+                f(&String::new());
+                loop {}
+            }
             f(&String::new());
             assert_eq!(count(), 1);
 
@@ -275,15 +273,17 @@ mod custom_dyn {
             let dyn_fn: StackBoxDynFnOnceRef<'_, str> = stackbox.into_dyn();
             assert_eq!(count(), 2);
             // The following would fail should the lifetime param not be higher-order
-            if false { dyn_fn.call(&String::new()); loop {} }
+            if false {
+                dyn_fn.call(&String::new());
+                loop {}
+            }
             dyn_fn.call(&String::new());
             assert_eq!(count(), 1);
         }
     }
 
     #[test]
-    fn non_owned_receiver ()
-    {
+    fn non_owned_receiver() {
         use ::core::any;
 
         /// Hack to have invocations work inside function bodies for the MSRV.
@@ -353,4 +353,5 @@ macro_rules! compile_fail {(#[doc = $doc:expr] $item:item) => (#[doc = $doc] $it
         )]
         pub mod $name {}
     }
-)} use compile_fail;
+)}
+use compile_fail;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,18 +1,8 @@
 //! [`StackBox`]: `StackBox`
 //!
-#![cfg_attr(feature = "docs",
-    feature(external_doc),
-    doc(include = "../README.md"),
-)]
-#![cfg_attr(
-    not(any(doc, feature = "std", test)),
-    no_std,
-)]
-#![cfg_attr(
-    feature = "const-generics",
-    feature(min_const_generics),
-)]
-
+#![cfg_attr(feature = "docs", feature(external_doc), doc(include = "../README.md"))]
+#![cfg_attr(not(any(doc, feature = "std", test)), no_std)]
+#![cfg_attr(feature = "const-generics", feature(min_const_generics))]
 #![allow(unused_parens)]
 #![deny(rust_2018_idioms)]
 #![allow(explicit_outlives_requirements)] // much unsafe code; better safe than sorry
@@ -23,8 +13,7 @@ extern crate alloc;
 #[cfg(test)]
 extern crate self as stackbox;
 
-pub
-mod dyn_traits;
+pub mod dyn_traits;
 
 mod marker;
 
@@ -39,32 +28,27 @@ mod stackbox_mod;
 
 /// This crates prelude: usage of this crate is designed to be ergonomic
 /// provided all the items within this module are in scope.
-pub
-mod prelude {
+pub mod prelude {
     #[doc(no_inline)]
     pub use crate::{
         custom_dyn,
-        dyn_traits::{
-            any::StackBoxDynAny,
-            fn_once::*,
-        },
-        mk_slot,
-        mk_slots,
-        stackbox,
-        StackBox,
+        dyn_traits::{any::StackBoxDynAny, fn_once::*},
+        mk_slot, mk_slots, stackbox, StackBox,
     };
 }
 
-#[doc(hidden)] /** Macro internals, not subject to semver rules */ pub
-mod __ {
-    pub use ::core::{
-        marker::Sized,
-        mem::ManuallyDrop,
-    };
+#[doc(hidden)]
+/** Macro internals, not subject to semver rules */
+pub mod __ {
+    pub use ::core::{marker::Sized, mem::ManuallyDrop};
 
     pub trait GetVTable {
         type VTable;
     }
+    pub use crate::{
+        dyn_traits::__::DynCoerce,
+        marker::{NoAutoTraits, Sendness::T as Sendness, Syncness::T as Syncness},
+    };
     pub use ::core::{
         concat,
         marker::{PhantomData, Send, Sync},
@@ -72,16 +56,12 @@ mod __ {
         ops::Drop,
     };
     pub use ::paste::paste;
-    pub use crate::{
-        marker::{Sendness::T as Sendness, Syncness::T as Syncness, NoAutoTraits},
-        dyn_traits::__::DynCoerce,
-    };
-    mod ty { pub struct Erased(()); }
+    mod ty {
+        pub struct Erased(());
+    }
     pub type ErasedPtr = ::core::ptr::NonNull<ty::Erased>;
 
-    pub
-    unsafe fn drop_in_place<T> (ptr: ErasedPtr)
-    {
+    pub unsafe fn drop_in_place<T>(ptr: ErasedPtr) {
         ::core::ptr::drop_in_place::<T>(ptr.cast::<T>().as_ptr());
     }
 }

--- a/src/marker.rs
+++ b/src/marker.rs
@@ -1,8 +1,7 @@
 mod sealed {
     use super::*;
 
-    pub
-    trait RepresentsAutoTraits {}
+    pub trait RepresentsAutoTraits {}
 
     impl RepresentsAutoTraits for dyn Send + 'static {}
     impl RepresentsAutoTraits for dyn Sync + 'static {}
@@ -10,15 +9,9 @@ mod sealed {
     impl RepresentsAutoTraits for NoAutoTraits {}
 }
 
-pub
-struct NoAutoTraits (
-    PhantomNotSendNorSync,
-    ::core::convert::Infallible,
-);
+pub struct NoAutoTraits(PhantomNotSendNorSync, ::core::convert::Infallible);
 
-type PhantomNotSendNorSync =
-    ::core::marker::PhantomData<*mut ()>
-;
+type PhantomNotSendNorSync = ::core::marker::PhantomData<*mut ()>;
 
 // struct PhantomNotSend(PhantomNotSendNorSync);
 // unsafe // Safety: no API whatsoever.
@@ -42,13 +35,12 @@ type PhantomNotSendNorSync =
 /// }
 /// # } fn main () {}
 /// ```
-#[doc(hidden)] #[allow(nonstandard_style)]
-pub
-mod Sendness {
+#[doc(hidden)]
+#[allow(nonstandard_style)]
+pub mod Sendness {
     use super::*;
 
-    pub
-    trait T : sealed::RepresentsAutoTraits {}
+    pub trait T: sealed::RepresentsAutoTraits {}
 
     impl T for dyn Send {}
     impl T for dyn Sync {}
@@ -70,13 +62,12 @@ mod Sendness {
 /// }
 /// # } fn main () {}
 /// ```
-#[doc(hidden)] #[allow(nonstandard_style)]
-pub
-mod Syncness {
+#[doc(hidden)]
+#[allow(nonstandard_style)]
+pub mod Syncness {
     use super::*;
 
-    pub
-    trait T : sealed::RepresentsAutoTraits {}
+    pub trait T: sealed::RepresentsAutoTraits {}
 
     impl T for dyn Send {}
     impl T for dyn Sync {}

--- a/src/ptr.rs
+++ b/src/ptr.rs
@@ -13,138 +13,91 @@
 //! to stable Rust… 😩
 
 #[allow(unused_imports)]
-pub(in crate)
-use ::core::ptr::*;
+pub(crate) use ::core::ptr::*;
 
-pub(in crate)
-use __::Unique;
+pub(crate) use __::Unique;
 
 #[cfg(feature = "alloc")]
-pub(in crate)
-mod __ {
+pub(crate) mod __ {
     use ::alloc::boxed::Box;
-    use ::core::{
-        mem::ManuallyDrop as MD,
-        ptr,
-    };
+    use ::core::{mem::ManuallyDrop as MD, ptr};
 
     #[repr(transparent)]
-    pub(in crate)
-    struct Unique<T : ?Sized> /* = */ (
-        MD<Box<T>>,
-    );
+    pub(crate) struct Unique<T: ?Sized>(MD<Box<T>>);
 
-    impl<T : ?Sized> Unique<T> {
+    impl<T: ?Sized> Unique<T> {
         #[inline]
-        pub(in crate)
-        unsafe
-        fn from_raw (ptr: *mut T)
-          -> Unique<T>
-        {
+        pub(crate) unsafe fn from_raw(ptr: *mut T) -> Unique<T> {
             Self(MD::new(Box::from_raw(ptr)))
         }
 
         #[inline]
-        pub(in crate)
-        fn into_raw_nonnull (self: Unique<T>)
-          -> ptr::NonNull<T>
-        {
-            Box::leak(MD::into_inner(self.0))
-                .into()
+        pub(crate) fn into_raw_nonnull(self: Unique<T>) -> ptr::NonNull<T> {
+            Box::leak(MD::into_inner(self.0)).into()
         }
 
         #[inline]
-        pub(in crate)
-        unsafe
-        fn drop_in_place (this: &'_ mut Unique<T>)
-        {
+        pub(crate) unsafe fn drop_in_place(this: &'_ mut Unique<T>) {
             ptr::drop_in_place::<T>(&mut **this)
         }
     }
 
-    impl<T : ?Sized> ::core::ops::Deref
-        for Unique<T>
-    {
+    impl<T: ?Sized> ::core::ops::Deref for Unique<T> {
         type Target = T;
 
         #[inline]
-        fn deref (self: &'_ Unique<T>)
-          -> &'_ T
-        {
+        fn deref(self: &'_ Unique<T>) -> &'_ T {
             &**self.0
         }
     }
 
-    impl<T : ?Sized> ::core::ops::DerefMut
-        for Unique<T>
-    {
+    impl<T: ?Sized> ::core::ops::DerefMut for Unique<T> {
         #[inline]
-        fn deref_mut (self: &'_ mut Unique<T>)
-          -> &'_ mut T
-        {
+        fn deref_mut(self: &'_ mut Unique<T>) -> &'_ mut T {
             &mut **self.0
         }
     }
 }
 
 #[cfg(not(feature = "alloc"))]
-pub(in crate)
-mod __ {
+pub(crate) mod __ {
     use ::core::ptr;
 
     #[repr(transparent)]
-    pub(in crate)
-    struct Unique<T : ?Sized> /* = */ (
-        ptr::NonNull<T>,
-    );
+    pub(crate) struct Unique<T: ?Sized>(ptr::NonNull<T>);
 
-    impl<T : ?Sized> Unique<T> {
+    unsafe impl<T: Send + ?Sized> Send for Unique<T> {}
+    unsafe impl<T: Sync + ?Sized> Sync for Unique<T> {}
+
+    impl<T: ?Sized> Unique<T> {
         #[inline]
-        pub(in crate)
-        unsafe
-        fn from_raw (ptr: *mut T)
-          -> Unique<T>
-        {
+        pub(crate) unsafe fn from_raw(ptr: *mut T) -> Unique<T> {
             Self(ptr::NonNull::new_unchecked(ptr))
         }
 
         #[inline]
-        pub(in crate)
-        fn into_raw_nonnull (self: Unique<T>)
-          -> ptr::NonNull<T>
-        {
+        pub(crate) fn into_raw_nonnull(self: Unique<T>) -> ptr::NonNull<T> {
             self.0
         }
 
         #[inline]
-        pub(in crate)
-        unsafe
-        fn drop_in_place (this: &'_ mut Unique<T>)
-        {
+        pub(crate) unsafe fn drop_in_place(this: &'_ mut Unique<T>) {
             ptr::drop_in_place(this.0.as_ptr())
         }
     }
 
-    impl<T : ?Sized> ::core::ops::Deref
-        for Unique<T>
-    {
+    impl<T: ?Sized> ::core::ops::Deref for Unique<T> {
         type Target = T;
 
         #[inline]
-        fn deref (self: &'_ Unique<T>)
-          -> &'_ T
-        {
+        fn deref(self: &'_ Unique<T>) -> &'_ T {
             unsafe { self.0.as_ref() }
         }
     }
 
-    impl<T : ?Sized> ::core::ops::DerefMut
-        for Unique<T>
-    {
+    impl<T: ?Sized> ::core::ops::DerefMut for Unique<T> {
         #[inline]
-        fn deref_mut (self: &'_ mut Unique<T>)
-          -> &'_ mut T
-        {
+        fn deref_mut(self: &'_ mut Unique<T>) -> &'_ mut T {
             unsafe { self.0.as_mut() }
         }
     }

--- a/src/slot.rs
+++ b/src/slot.rs
@@ -18,11 +18,7 @@ use ::core::{
 ///
 /// [`.stackbox()`]: `Slot::stackbox`
 #[inline(always)]
-pub
-const
-fn mk_slot<T> ()
-  -> Slot<T>
-{
+pub const fn mk_slot<T>() -> Slot<T> {
     Slot::VACANT
 }
 
@@ -32,8 +28,7 @@ fn mk_slot<T> ()
 /// If needed, multiple such slots can be defined within the local scope and
 /// bound to a variadic number of identifiers (variable names) using the
 /// [`mk_slots!`][`crate::mk_slots`] macro.
-pub
-struct Slot<T> {
+pub struct Slot<T> {
     place: mem::MaybeUninit<T>,
     // /// Invariant lifetime just in case.
     // _borrow_mut_once: PhantomData<fn(&()) -> &mut &'frame ()>,
@@ -48,19 +43,16 @@ impl<T> Slot<T> {
     ///   - or the equivalent [`.stackbox()`] convenience method on [`Slot`]s.
     ///
     /// [`.stackbox()`]: `Slot::stackbox`
-    pub
-    const VACANT: Self = Slot {
+    pub const VACANT: Self = Slot {
         place: mem::MaybeUninit::uninit(),
         // _borrow_mut_once: PhantomData,
     };
 
     /// Convenience shortcut for [`StackBox::new_in()`].
     #[inline(always)]
-    pub
-    fn stackbox<'frame> (self: &'frame mut Slot<T>, value: T)
-      -> StackBox<'frame, T>
+    pub fn stackbox<'frame>(self: &'frame mut Slot<T>, value: T) -> StackBox<'frame, T>
     where
-        T : 'frame,
+        T: 'frame,
     {
         let ptr = Self::__init_raw(self, value);
         unsafe {
@@ -69,17 +61,16 @@ impl<T> Slot<T> {
         }
     }
 
-    #[doc(hidden)] /** Not part of the public API */ pub
-    fn __init_raw<'frame> (this: &'frame mut Slot<T>, value: T)
-      -> &'frame mut ::core::mem::ManuallyDrop<T>
-    {
+    #[doc(hidden)]
+    /** Not part of the public API */
+    pub fn __init_raw<'frame>(
+        this: &'frame mut Slot<T>,
+        value: T,
+    ) -> &'frame mut ::core::mem::ManuallyDrop<T> {
         this.place = mem::MaybeUninit::new(value);
         unsafe {
             // Safety: value has been initialized.
-            mem::transmute::<
-                &'_ mut mem::MaybeUninit<T>,
-                &'_ mut mem::ManuallyDrop<T>,
-            >(
+            mem::transmute::<&'_ mut mem::MaybeUninit<T>, &'_ mut mem::ManuallyDrop<T>>(
                 &mut this.place,
             )
         }

--- a/src/stackbox/slice/iter.rs
+++ b/src/stackbox/slice/iter.rs
@@ -9,11 +9,29 @@ impl<'frame, Item: 'frame> Iterator for Iter<'frame, Item> {
     fn next(self: &'_ mut Iter<'frame, Item>) -> Option<Item> {
         self.0.pop_front()
     }
+
+    #[inline]
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        (self.0.len(), Some(self.0.len()))
+    }
+}
+
+impl<'frame, Item: 'frame> ExactSizeIterator for Iter<'frame, Item> {
+    #[inline]
+    fn len(&self) -> usize {
+        self.0.len()
+    }
+}
+
+impl<'frame, Item: 'frame> DoubleEndedIterator for Iter<'frame, Item> {
+    fn next_back(&mut self) -> Option<Self::Item> {
+        self.0.pop_back()
+    }
 }
 
 impl<'frame, Item: 'frame> IntoIterator for StackBox<'frame, [Item]> {
-    type IntoIter = Iter<'frame, Item>;
     type Item = Item;
+    type IntoIter = Iter<'frame, Item>;
 
     #[inline]
     fn into_iter(self: StackBox<'frame, [Item]>) -> Iter<'frame, Item> {

--- a/src/stackbox/slice/iter.rs
+++ b/src/stackbox/slice/iter.rs
@@ -1,31 +1,22 @@
 use crate::prelude::*;
 
-pub
-struct Iter<'frame, Item : 'frame> (
-    StackBox<'frame, [Item]>,
-);
+pub struct Iter<'frame, Item: 'frame>(StackBox<'frame, [Item]>);
 
-impl<'frame, Item : 'frame> Iterator for Iter<'frame, Item> {
+impl<'frame, Item: 'frame> Iterator for Iter<'frame, Item> {
     type Item = Item;
 
     #[inline]
-    fn next (self: &'_ mut Iter<'frame, Item>)
-      -> Option<Item>
-    {
-        self.0.stackbox_pop()
+    fn next(self: &'_ mut Iter<'frame, Item>) -> Option<Item> {
+        self.0.pop_front()
     }
 }
 
-impl<'frame, Item : 'frame> IntoIterator
-    for StackBox<'frame, [Item]>
-{
+impl<'frame, Item: 'frame> IntoIterator for StackBox<'frame, [Item]> {
     type IntoIter = Iter<'frame, Item>;
     type Item = Item;
 
     #[inline]
-    fn into_iter (self: StackBox<'frame, [Item]>)
-      -> Iter<'frame, Item>
-    {
+    fn into_iter(self: StackBox<'frame, [Item]>) -> Iter<'frame, Item> {
         Iter(self)
     }
 }
@@ -33,8 +24,7 @@ impl<'frame, Item : 'frame> IntoIterator
 #[cfg(test)]
 mod tests {
     #[test]
-    fn doctest_for_miri ()
-    {
+    fn doctest_for_miri() {
         use ::stackbox::prelude::*;
 
         stackbox!(let boxed_slice: StackBox<'_, [_]> = [


### PR DESCRIPTION
I tried to make a few improvements for `StackBox<[T]>`:

* Implement `StackBox<[T]>: Default` (Returns an empty slice that doesn't need any memory)
* Add a method to convert a `StackBox<[T]>` into a `StackBox<T>` by asserting it's size is 1.
* Re-implement `StackBox::stackbox_pop` safely using the previous two functions. 
* Rename `StackBox::stackbox_pop` to `StackBox::pop_front` 
  * This makes it more clear which side is popped from and matches `VecDeque::pop_front`
  * `StackBox::stackbox_pop` still exists but is now depracated
* Safely implement  `StackBox::pop_back` 
* Safely implement `DoubleEndedIterator` and `ExactSizedIterator` for `StackBox<[T]>::IntoIter`